### PR TITLE
fix search ch test

### DIFF
--- a/plaza_routing/tests/test_search_ch_api.py
+++ b/plaza_routing/tests/test_search_ch_api.py
@@ -3,10 +3,10 @@ from plaza_routing import search_ch_api
 
 
 def test_get_connection():
-    connection = search_ch_api.get_connection('Sternen Oerlikon', 'Altstetten', '14:11')
+    connection = search_ch_api.get_connection('Sternen Oerlikon', 'Zürich Altstetten', '14:11')
     assert connection is not None
     assert connection['from'] == 'Zürich, Sternen Oerlikon'
-    assert connection['to'] == 'Zürich Altstetten'
+    assert connection['to'] == 'Zürich Altstetten, Bahnhof'
     assert len(connection['legs']) == 4
     # last leg should be a final station or an address without an exit
     assert connection['legs'][3]['exit'] == []


### PR DESCRIPTION
test_get_connection() failed. Instead of Zürich Altstetten, Zürich Altstetten, Bahnhof was returned. Not sure if the API has changed or Altstetten as parameter was not precise enough.