### PR TITLE
Adjust start osm

### DIFF
--- a/plaza_preprocessing/plaza_preprocessing/importer/importer.py
+++ b/plaza_preprocessing/plaza_preprocessing/importer/importer.py
@@ -8,6 +8,8 @@ from plaza_preprocessing import configuration
 logger = logging.getLogger('plaza_preprocessing.importer')
 WKBFAB = osmium.geom.WKBFactory()
 
+OSM_MAX_ID = 10**10 
+
 
 def import_osm(filename, tag_filters):
     """ imports a OSM / PBF file and returns a holder with all plazas, buildings,
@@ -40,12 +42,14 @@ class _PlazaHandler(osmium.SimpleHandler):
 
     def node(self, node):
         if self._is_relevant_node(node):
+            _check_max_id(node.id)
             point_wkb = WKBFAB.create_point(node)
             point_geometry = wkblib.loads(point_wkb, hex=True)
             self.points.append(point_geometry)
 
     def way(self, way):
         if self._is_relevant_way(way):
+            _check_max_id(way.id)
             try:
                 line_wkb = WKBFAB.create_linestring(way)
                 line_geometry = wkblib.loads(line_wkb, hex=True)
@@ -63,6 +67,7 @@ class _PlazaHandler(osmium.SimpleHandler):
 
     def area(self, area):
         if self._is_plaza(area):
+            _check_max_id(area.id)
             multipolygon_geom = self._create_multipolygon(area)
             if multipolygon_geom:
                 for polygon in multipolygon_geom.geoms:
@@ -108,3 +113,8 @@ class _PlazaHandler(osmium.SimpleHandler):
     def _is_relevant_building(self, area):
         return "building" in area.tags \
             and area.tags.get("layer", "0") == "0"
+
+    def _check_max_id(self, osm_id):
+        if osm_id >= OSM_MAX_ID:
+            logger.error(f"OSM id {osm_id} is larger than the allowed {OSM_MAX_ID}")
+

--- a/plaza_preprocessing/plaza_preprocessing/importer/importer.py
+++ b/plaza_preprocessing/plaza_preprocessing/importer/importer.py
@@ -42,14 +42,14 @@ class _PlazaHandler(osmium.SimpleHandler):
 
     def node(self, node):
         if self._is_relevant_node(node):
-            _check_max_id(node.id)
+            self._check_max_id(node.id)
             point_wkb = WKBFAB.create_point(node)
             point_geometry = wkblib.loads(point_wkb, hex=True)
             self.points.append(point_geometry)
 
     def way(self, way):
         if self._is_relevant_way(way):
-            _check_max_id(way.id)
+            self._check_max_id(way.id)
             try:
                 line_wkb = WKBFAB.create_linestring(way)
                 line_geometry = wkblib.loads(line_wkb, hex=True)
@@ -67,7 +67,7 @@ class _PlazaHandler(osmium.SimpleHandler):
 
     def area(self, area):
         if self._is_plaza(area):
-            _check_max_id(area.id)
+            self._check_max_id(area.id)
             multipolygon_geom = self._create_multipolygon(area)
             if multipolygon_geom:
                 for polygon in multipolygon_geom.geoms:

--- a/plaza_preprocessing/plaza_preprocessing/merger/plazatransformer.py
+++ b/plaza_preprocessing/plaza_preprocessing/merger/plazatransformer.py
@@ -3,7 +3,7 @@ from osmium import SimpleWriter
 from osmium.osm.mutable import Way, Node
 
 
-OSM_ID_START = (-1) * 10**9
+OSM_ID_START = 10**10
 
 
 def transform_plazas(plazas, node_file, way_file, footway_tags):


### PR DESCRIPTION
- Newly inserted ways and nodes will have `osm_id`s starting with 10^10
- Log an error if an imported `osm_id` is greater than 10^10